### PR TITLE
Replace interactive prompts with "expect" scripts

### DIFF
--- a/2-install_api.sh
+++ b/2-install_api.sh
@@ -49,11 +49,11 @@ done
 
 # INFO, if you have issues with stale/old data, check for 
 # docker volume kernelci-api_mongodata and delete it
-./scripts/setup_admin_user --email ${YOUR_EMAIL}
+../../helpers/scripts_setup_admin_user.exp "${YOUR_EMAIL}" "${ADMIN_PASSWORD}"
 
 cd ../kernelci-core
 echo "Issuing token for admin user"
-./kci user token admin > ../../admin-token.txt
+../../helpers/kci_user_token_admin.exp "${ADMIN_PASSWORD}" > ../../admin-token.txt
 ADMIN_TOKEN=$(cat ../../admin-token.txt)
 
 echo "[kci.secrets]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Get your own KernelCI instance up and running in no time.
 - git
 - Docker (with `compose` plugin, set up for a regular user)
 - Python environment with [KernelCI core dependencies](https://github.com/kernelci/kernelci-core/blob/main/requirements.txt) installed
+- expect
 
 ### Running
 
-Run shell scripts from the root directory in their order.
+Change `ADMIN_PASSWORD` in the `main.cfg`, then run shell scripts from the root directory in their order.

--- a/helpers/kci_user_token_admin.exp
+++ b/helpers/kci_user_token_admin.exp
@@ -1,0 +1,10 @@
+#!/usr/bin/expect -f
+
+set password [lindex $argv 0]
+log_user 0
+spawn ./kci user token admin
+expect "Password:"
+send -- "$password\r"
+expect "\r\n"
+log_user 1
+expect eof

--- a/helpers/scripts_setup_admin_user.exp
+++ b/helpers/scripts_setup_admin_user.exp
@@ -1,0 +1,9 @@
+#!/usr/bin/expect -f
+
+set password [lindex $argv 1]
+spawn ./scripts/setup_admin_user --email [lindex $argv 0]
+expect "Password for user 'admin':"
+send -- "$password\r"
+expect "Retype password for user 'admin':"
+send -- "$password\r"
+expect eof

--- a/main.cfg
+++ b/main.cfg
@@ -6,5 +6,6 @@ KCI_API_BRANCH=staging.kernelci.org
 KCI_PIPELINE_REPO=https://github.com/kernelci/kernelci-pipeline
 KCI_PIPELINE_BRANCH=staging.kernelci.org
 YOUR_EMAIL=denys.f@collabora.com
+ADMIN_PASSWORD="Ch4n93m3HpL33z"
 STORAGE_TOKEN="FKDFLKJFLKDJFLK"
 #KCI_CACHE=1


### PR DESCRIPTION
This patch adds a new dependency to the setup: expect. It is necessary because this change replaces interaction with protected password inputs which won't work with simple echos.

New helper scripts were based on "expect_autopasswd" script shipped with "expect" package as well as "autoexpect" output for corresponding commands.

Remember to change sample admin password before bringing up this setup.

Fixes: #2